### PR TITLE
如果图片高度超出屏幕高,使其高度等于屏幕高

### DIFF
--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -213,9 +213,14 @@ layer.photos = function(options, loop, key){
                var imgarea = [img.width, img.height];
                var winarea = [$(window).width() - 100, $(window).height() - 100];
                if(!options.full && imgarea[0] > winarea[0]){
+                   imgarea[1] = imgarea[1]*winarea[0]/imgarea[0];
                    imgarea[0] = winarea[0];
-                   imgarea[1] = imgarea[0]*winarea[1]/imgarea[0];
                }
+               
+               if (!options.full && imgarea[1] > winarea[1]) {
+                    imgarea[0] = imgarea[0]*winarea[1]/imgarea[1];
+                    imgarea[1] = winarea[1];
+               };
                return [imgarea[0]+'px', imgarea[1]+'px']; 
             }(),
             title: false,


### PR DESCRIPTION
项目在用，今天发现了bug
1：当图片宽度>屏幕宽时， 
 图片宽度等于屏幕宽，高度设置不正确，已修改

2: 新增 图片高度判断
