### PR TITLE
Update layer.ext.js

### DIFF
--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -96,7 +96,7 @@ layer.photos = function(options, loop, key){
     if(!type){ //页面直接获取
         var parent = $(options.photos), img = parent.find(options.img||'img');
         if (img.length === 0) return;
-        loop || parent.find(photos.img||'img').each(function(index){
+        loop || img.each(function(index){
             var othis = $(this);
             data.push({
                 alt: othis.attr('alt'),


### PR DESCRIPTION
你好，我在使用过程中发现了一小处问题见修改记录。

上面已经写了
img = parent.find(options.img||'img')
下面这段明显是写错了（options.img写成了photos.img），
而且没必要再查找一遍子元素
parent.find(photos.img||'img')