### PR TITLE
增加了几点，请看看是否需要，（相册的事件改为托管方式）

### DIFF
--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -98,13 +98,9 @@ layer.photos = function(options, loop, key){
         if (img.length === 0) return;
         loop || img.each(function(index){
             var othis = $(this);
-            data.push({
-                alt: othis.attr('alt'),
-                pid: othis.attr('layer-pid'),
-                src: othis.attr('layer-src') || othis.attr('src'),
-                thumb: othis.attr('src')
-            });
-            othis.on('click', function(){
+            data.push(othis);
+            othis.on('click', function(e){
+                e.preventDefault();
                 layer.photos($.extend(options, {
                     photos: {
                         start: index,
@@ -188,7 +184,7 @@ layer.photos = function(options, loop, key){
     };
     
     //图片预加载
-    function loadImage(url, callback, error) {     
+    function loadImage(element, callback, error) {
         var img = new Image();    
         img.onload = function(){
             img.onload = null;
@@ -198,14 +194,15 @@ layer.photos = function(options, loop, key){
             img.onerror = null;
             error(e);
         };
-        img.src = url; 
+        img.src = element.attr('layer-src') || element.attr('src') || element.attr('href');
+        img.alt = element.attr('alt') || element.attr('title') || '';
     };
     
     dict.loadi = layer.load(1, {
         shade: 'shade' in options ? false : 0.9,
         scrollbar: false
     });
-    loadImage(data[start].src, function(img){
+    loadImage(data[start], function(img){
         layer.close(dict.loadi);
         dict.index = layer.open($.extend({
             type: 1,
@@ -229,10 +226,10 @@ layer.photos = function(options, loop, key){
             shift: Math.random()*5|0,
             skin: 'layui-layer-photos' + skin('photos'),
             content: '<div class="layui-layer-phimg">'
-                +'<img src="'+ data[start].src +'" alt="'+ (data[start].alt||'') +'" layer-pid="'+ data[start].pid +'">'
+                +'<img src="'+ img.src +'" alt="'+ (img.alt) +'" layer-pid="'+ (data[start].attr('layer-pid') || '') +'">'
                 +'<div class="layui-layer-imgsee">'
                     +(data.length > 1 ? '<span class="layui-layer-imguide"><a href="javascript:;" class="layui-layer-iconext layui-layer-imgprev"></a><a href="javascript:;" class="layui-layer-iconext layui-layer-imgnext"></a></span>' : '')
-                    +'<div class="layui-layer-imgbar" style="display:'+ (key ? 'block' : '') +'"><span class="layui-layer-imgtit"><a href="javascript:;">'+ (data[start].alt||'') +'</a><em>'+ dict.imgIndex +'/'+ data.length +'</em></span></div>'
+                    +'<div class="layui-layer-imgbar" style="display:'+ (key ? 'block' : '') +'"><span class="layui-layer-imgtit"><a href="javascript:;">'+ (img.alt) +'</a><em>'+ dict.imgIndex +'/'+ data.length +'</em></span></div>'
                 +'</div>'
             +'</div>',
             success: function(layero, index){

--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -94,19 +94,34 @@ layer.photos = function(options, loop, key){
     dict.imgIndex = start + 1;
 
     if(!type){ //页面直接获取
-        var parent = $(options.photos), img = parent.find(options.img||'img');
-        if (img.length === 0) return;
-        loop || img.each(function(index){
-            var othis = $(this);
-            data.push({
-                alt: othis.attr('alt') || othis.attr('title') || '',
-                pid: othis.attr('layer-pid') || '',
-                src: othis.attr('layer-src') || othis.attr('src') || othis.attr('href'),
-                thumb: othis.attr('src')
+        var parent = $(options.photos);
+        //不直接弹出
+        if(!loop){
+            function push_data(othis){
+                data.push({
+                    alt: othis.attr('alt') || othis.attr('title') || '',
+                    pid: othis.attr('layer-pid') || '',
+                    src: othis.attr('layer-src') || othis.attr('src') || othis.attr('href'),
+                    thumb: othis.attr('src')
+                });
+                return data.length;
+            }
+            parent.find(options.img||'img').each(function(index){
+                var othis = $(this);
+                othis.data('_index',index);
+                push_data(othis);
             });
-            othis.on('click', function(e){
+
+            parent.on('click',options.img,function(e){
                 e.preventDefault();
-                data[index].src = othis.attr('layer-src') || othis.attr('src') || othis.attr('href');
+                var othis = $(this);
+                var index = othis.data('_index');
+                if(data[index] == null){
+                    index = push_data(othis)-1;
+                    othis.data('_index',index);
+                }else{
+                    data[index].src = othis.attr('layer-src') || othis.attr('src') || othis.attr('href');
+                }
                 layer.photos($.extend(options, {
                     photos: {
                         start: index,
@@ -116,10 +131,8 @@ layer.photos = function(options, loop, key){
                     full: options.full
                 }), true);
             });
-        });
-        
-        //不直接弹出
-        if(!loop) return;
+            return;
+        };
         
     } else if (data.length === 0){
         layer.msg('&#x6CA1;&#x6709;&#x56FE;&#x7247;');

--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -112,7 +112,7 @@ layer.photos = function(options, loop, key){
                 push_data(othis);
             });
 
-            parent.on('click',options.img,function(e){
+            parent.on('click',options.img||'img',function(e){
                 e.preventDefault();
                 var othis = $(this);
                 var index = othis.data('_index');

--- a/src/extend/layer.ext.js
+++ b/src/extend/layer.ext.js
@@ -98,9 +98,15 @@ layer.photos = function(options, loop, key){
         if (img.length === 0) return;
         loop || img.each(function(index){
             var othis = $(this);
-            data.push(othis);
+            data.push({
+                alt: othis.attr('alt') || othis.attr('title') || '',
+                pid: othis.attr('layer-pid') || '',
+                src: othis.attr('layer-src') || othis.attr('src') || othis.attr('href'),
+                thumb: othis.attr('src')
+            });
             othis.on('click', function(e){
                 e.preventDefault();
+                data[index].src = othis.attr('layer-src') || othis.attr('src') || othis.attr('href');
                 layer.photos($.extend(options, {
                     photos: {
                         start: index,
@@ -184,7 +190,7 @@ layer.photos = function(options, loop, key){
     };
     
     //图片预加载
-    function loadImage(element, callback, error) {
+    function loadImage(url, callback, error) {
         var img = new Image();    
         img.onload = function(){
             img.onload = null;
@@ -194,15 +200,14 @@ layer.photos = function(options, loop, key){
             img.onerror = null;
             error(e);
         };
-        img.src = element.attr('layer-src') || element.attr('src') || element.attr('href');
-        img.alt = element.attr('alt') || element.attr('title') || '';
+        img.src = url;
     };
     
     dict.loadi = layer.load(1, {
         shade: 'shade' in options ? false : 0.9,
         scrollbar: false
     });
-    loadImage(data[start], function(img){
+    loadImage(data[start].src, function(img){
         layer.close(dict.loadi);
         dict.index = layer.open($.extend({
             type: 1,
@@ -226,10 +231,10 @@ layer.photos = function(options, loop, key){
             shift: Math.random()*5|0,
             skin: 'layui-layer-photos' + skin('photos'),
             content: '<div class="layui-layer-phimg">'
-                +'<img src="'+ img.src +'" alt="'+ (img.alt) +'" layer-pid="'+ (data[start].attr('layer-pid') || '') +'">'
+                +'<img src="'+ img.src +'" alt="'+ data[start].alt +'" layer-pid="'+ data[start].pid +'">'
                 +'<div class="layui-layer-imgsee">'
                     +(data.length > 1 ? '<span class="layui-layer-imguide"><a href="javascript:;" class="layui-layer-iconext layui-layer-imgprev"></a><a href="javascript:;" class="layui-layer-iconext layui-layer-imgnext"></a></span>' : '')
-                    +'<div class="layui-layer-imgbar" style="display:'+ (key ? 'block' : '') +'"><span class="layui-layer-imgtit"><a href="javascript:;">'+ (img.alt) +'</a><em>'+ dict.imgIndex +'/'+ data.length +'</em></span></div>'
+                    +'<div class="layui-layer-imgbar" style="display:'+ (key ? 'block' : '') +'"><span class="layui-layer-imgtit"><a href="javascript:;">'+ (data[start].alt||'') +'</a><em>'+ dict.imgIndex +'/'+ data.length +'</em></span></div>'
                 +'</div>'
             +'</div>',
             success: function(layero, index){

--- a/test/demo2.html
+++ b/test/demo2.html
@@ -1,0 +1,95 @@
+﻿<!doctype html>
+<html>
+<head>
+<title>layer-更懂你的web弹窗解决方案</title>
+<script src="http://lib.sinaapp.com/js/jquery/1.9.1/jquery-1.9.1.min.js"></script>
+<script src="../src/layer.js?v=1.9.0"></script>
+
+<style>
+html{background-color:#E3E3E3; font-size:14px; color:#000; font-family:'微软雅黑'}
+a,a:hover{ text-decoration:none;}
+pre{font-family:'微软雅黑'}
+.box{padding:20px; background-color:#fff; margin:50px 100px; border-radius:5px;}
+.box a{padding-right:15px;}
+#about_hide{display:none}
+.layer_text{background-color:#fff; padding:20px;}
+.layer_text p{margin-bottom: 10px; text-indent: 2em; line-height: 23px;}
+.button{display:inline-block; *display:inline; *zoom:1; line-height:30px; padding:0 20px; background-color:#56B4DC; color:#fff; font-size:14px; border-radius:3px; cursor:pointer; font-weight:normal;}
+.photos-demo img{width:200px;}
+</style>
+</head>
+<body>
+<div class="box">
+<pre>
+ @Name：layer-v<script>document.write(layer.v)</script> 弹层组件说明
+ @Author：贤心
+ @Blog：<a href="http://sentsin.com" target="_blank">http://sentsin.com</a>
+ @Site：<a href="http://sentsin.com/jquery/layer/?form=local"  target="_blank">http://sentsin.com/jquery/layer</a>
+
+
+<strong>【注意事项】</strong>
+一、使用时，请把文件夹layer整个放置在您站点的任何一个目录，只需引入layer.js即可，除jQuery外，其它文件无需再引入。
+二、如果您的js引入是通过合并处理或者您不想采用layer自动获取的绝对路径，您可以通过layer.config()来配置（详见官网API页）
+三、jquery需1.8+
+四、更多使用说明与演示，请参见layer官网。
+五、使用时请务必保留来源，请勿用于违反我国法律的web平台。
+六、layer遵循LGPL协议，将永久性提供无偿服务。版权最终解释权：贤心。
+</pre>
+</div>
+
+<div class="box">
+    <h2 style="padding-bottom:20px;">扩展模块：图片查看器（相册层）</h2>
+    <div style="margin-bottom: 10px;">
+        <button id="change-src">点我第一张图片会变哦！</button>
+    </div>
+    <div id="photosDemo" class="photos-demo">
+        <!-- layer-src表示大图  layer-pid表示图片id  src表示缩略图-->
+
+        <a id="a-element-demo" class="layer-photos-img" href="http://ww2.sinaimg.cn/mw1024/5db11ff4jw1ehcyirr6quj20q00ex42w.jpg" title="国足" layer-pid="" ><img src="http://ww2.sinaimg.cn/mw1024/5db11ff4jw1ehcyirr6quj20q00ex42w.jpg" ></a>
+        <img class="layer-photos-img" layer-src="http://static.oschina.net/uploads/space/2014/0516/012728_nAh8_1168184.jpg" layer-pid="" src="http://static.oschina.net/uploads/space/2014/0516/012728_nAh8_1168184.jpg" alt="layer宣传图">
+        <img class="layer-photos-img" layer-src="http://sentsin.qiniudn.com/sentsinmy5.jpg" layer-pid="" src="http://sentsin.qiniudn.com/sentsinmy5.jpg" alt="我入互联网这五年">
+        <img class="layer-photos-img" layer-src="" layer-pid="" src="http://sentsin.qiniudn.com/sentsin_39101a660cf4671b7ec297a74cc652c74152104f.jpg" alt="微摄影">
+    </div>
+</div>
+
+
+<div class="box" style="text-align:center">
+    <a href="http://sentsin.com/jquery/layer/?form=local" target="_blank">更多示例</a>
+    <a href="http://sentsin.com/jquery/layer/api.html?form=local" target="_blank">使用文档</a>
+    <a href="http://say.sentsin.com/home-48.html?form=local" id="suggest">交流反馈</a>
+    <a href="javascript:;" id="about">关于</a>
+</div>
+
+<script>
+;!function(){
+
+//加载扩展模块
+layer.config({
+    extend: 'extend/layer.ext.js'
+});
+
+//页面一打开就执行，放入ready是为了layer所需配件（css、扩展模块）加载完毕
+layer.ready(function(){ 
+    layer.tips('我跟其他几个不一样哦，我是A标签！', '#a-element-demo', {tips: 3})
+    //layer.msg('欢迎使用layer');
+    
+    //使用相册
+    layer.photos({
+        photos: '#photosDemo',
+        img:'.layer-photos-img'
+    });
+});
+
+$('#change-src').click(function(){
+    $("#a-element-demo").attr('href','http://sentsin.qiniudn.com/sentsinsan01.jpg')
+            .children('img').attr('src','http://sentsin.qiniudn.com/sentsinsan01.jpg');
+});
+//关于
+$('#about').on('click', function(){
+    layer.alert(layer.v + ' - 贤心出品 sentsin.com');
+});
+
+}();
+</script>
+</body>
+</html>


### PR DESCRIPTION
1、将相册的事件改为托管方式
2、原有的代码A标签支持不太方便（有时可能A标签用得更多一些，比如&lt;a href="xxxx"&gt;预览&lt;/a&gt;）
3、在元素的layer-src、src或href的值发生改变的情况下，无法检测到。（比如在做上传图片的时候，想在上传成功后点击小图放大查看）

新的修改点是对上面两点的补充