### PR TITLE
add jquery module dependency for requirejs

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -786,7 +786,7 @@ ready.run = function(){
   };
 };
 
-'function' === typeof define ? define(function(){
+'function' === typeof define ? define(['jquery'], function(){
   ready.run();
   return layer;
 }) : function(){


### PR DESCRIPTION
after this fix,  you do not have to add shim in requirejs like: 
```js
    shim: {       
        layer: {
            deps: ['jquery']
        }
    }
```