### PR TITLE
[“捕获层“低版本ie兼容性调整]

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -297,7 +297,8 @@ Class.pt.creat = function(){
         $('body').append(html[1]);
       }() : function(){
         if(!content.parents('.'+doms[0])[0]){
-          content.data('display', content.css('display')).show().addClass('layui-layer-wrap').wrap(html[1]);
+          // zjruan 20170315 【修改捕获页位置】 移动捕获层到页面底部
+          content.data('display', content.css('display')).show().addClass('layui-layer-wrap').after('<div id="'+ doms[0] + times +'-placeholder"></div>').appendTo('body').wrap(html[1]);
           $('#'+ doms[0] + times).find('.'+doms[5]).before(titleHTML);
         }
       }();
@@ -878,7 +879,8 @@ layer.close = function(index){
       for(var i = 0; i < 2; i++){
         wrap.unwrap();
       }
-      wrap.css('display', wrap.data('display')).removeClass(WRAP);
+      // zjruan 20170315 【修改捕获页位置】 还原捕获层位置
+      wrap.css('display', wrap.data('display')).removeClass(WRAP).replaceAll($('#'+ doms[0] + index +'-placeholder'));
     } else {
       //低版本IE 回收 iframe
       if(type === ready.type[2]){


### PR DESCRIPTION
layerjs 是一个非常棒的弹窗库，官方介绍时说兼容ie6，但实际上是有一些问题的。“捕获页”是我们常用的一个功能之一，但它的实现方式，使得它不兼容低版本ie。
```
// 测试demo地址，http://layer.layui.com/
// 验证代码
layer.open({
  type: 1,
  shade: false,
  title: false, 
  content:$('#chutiyan'), 
  cancel: function(){
  }
});
```
问题原因：低版本ie有一个bug，就是 z-index 受其父元素z-index影响，当 a 元素的定位低于 其兄弟元素 b 的定位时，那么 a 元素所有的子元素 a-n 的定位都会低于 b元素

解决方案：将捕获元素至于页面的最底部并在原位置添加一个占位元素，当关闭弹窗时，再将占位元素还原为捕获元素