### PR TITLE
关闭方法中的innerHTML 导致IE9崩溃

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -912,6 +912,8 @@ layer.close = function(index){
           layero.find('.'+doms[5])[0].removeChild(iframe);
         } catch(e){}
       }
+      //这里的innerHTML 在IE9中调用关闭导致IE崩溃
+     //我使用这里注释了下面第一行，元芳怎么看？
       layero[0].innerHTML = '';
       layero.remove();
     }


### PR DESCRIPTION
注释已经添加，不知道元芳怎么看