### PR TITLE
优化标题兼容性

### DIFF
--- a/src/mobile/need/layer.css
+++ b/src/mobile/need/layer.css
@@ -26,7 +26,7 @@
 .layermbox0 .layermchild{max-width:90%; min-width:150px;}
 .layermbox1 .layermchild{border:none; border-radius:0;}
 .layermbox2 .layermchild{width:auto; max-width:260px; min-width:40px; border:none; background: none; box-shadow: none; color:#fff;}
-.layermchild h3{padding:0 45px 0 10px; height:50px; line-height:50px; border-bottom:1px solid #EBEBEB; font-size:16px; font-weight:400;  border-radius:3px 3px 0 0; border-bottom:1px solid #EBEBEB;}
+.layermchild h3{margin: 0; padding:0 45px 0 10px; height:50px; line-height:50px; border-bottom:1px solid #EBEBEB; font-size:16px; font-weight:400;  border-radius:3px 3px 0 0; border-bottom:1px solid #EBEBEB;}
 .layermchild h3,
 .layermbtn span{ text-overflow:ellipsis; overflow:hidden; white-space:nowrap;}
 .layermcont{padding:20px 15px; line-height:22px; text-align:center;}


### PR DESCRIPTION
提示消息中的标题在没有 reset.css 重置下，会导致标题样式被 margin 打乱，所以可以加上`margin: 0`来解决这个问题