### PR TITLE
修复弹出层关闭后，页面未完全清除元素的问题

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -933,7 +933,7 @@ layer.close = function(index){
     layero.addClass('layer-anim '+ closeAnim);
   }
   
-  $('#layui-layer-moves, #layui-layer-shade' + index).remove();
+  $('.layui-layer-move, #layui-layer-shade' + index).remove();
   layer.ie == 6 && ready.reselect();
   ready.rescollbar(index); 
   if(layero.attr('minLeft')){


### PR DESCRIPTION
- 弹出层点击关闭使用`layer.close`函数，弹出层点击关闭后清除页面中所有弹出层元素。
    - `layer.js`中第936行`$('#layui-layer-moves, #layui-layer-shade' + index).remove();`，弹出层元素中`#layui-layer-moves` 不存在，修改为 `.layui-layer-move`
