### PR TITLE
iPad Pro 中打开页面最小宽度大于 1024px 的页面时弹窗位置任然相对 于 1024px 定位

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -409,7 +409,7 @@ Class.pt.offset = function(){
   var area = [layero.outerWidth(), layero.outerHeight()];
   var type = typeof config.offset === 'object';
   that.offsetTop = (win.height() - area[1])/2;
-  that.offsetLeft = (win.width() - area[0])/2;
+  that.offsetLeft = ((window.innerWidth) - area[0])/2;
   
   if(type){
     that.offsetTop = config.offset[0];


### PR DESCRIPTION
iPad Pro 中使用 `layer.open()` 打开页面最小宽度大于 1024px 的页面时弹窗位置任然相对 于 1024px 定位